### PR TITLE
test: use master key client to create user

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -7040,7 +7040,7 @@ describe('ParseGraphQLServer', () => {
           options: { anOption: true },
         };
 
-        it('should create user and return authData response', async () => {
+        fit('should create user and return authData response', async () => {
           parseServer = await global.reconfigureServer({
             publicServerURL: 'http://localhost:13377/parse',
             auth: {
@@ -7071,6 +7071,11 @@ describe('ParseGraphQLServer', () => {
                     },
                   },
                 },
+              },
+            },
+            context: {
+              headers: {
+                'X-Parse-Master-Key': 'test',
               },
             },
           });


### PR DESCRIPTION
grpahql test used an "anonymous" client to create the user, now it's impossible if `enforcePrivateUser` is activated.

I updated the test to use the master client since it's better real world test.

Allowing anonymous user creation with enforcePrivateUser to true is kind of a non sense